### PR TITLE
Add option ZeroAsNull (Fixes: #30)

### DIFF
--- a/cmd/yaml-diff/main.go
+++ b/cmd/yaml-diff/main.go
@@ -12,6 +12,7 @@ import (
 
 func main() {
 	ignoreEmptyFields := flag.Bool("ignore-empty-fields", false, "Ignore empty field")
+	ignoreZeroFields := flag.Bool("ignore-zero-fields", false, "Ignore zero field")
 	flag.Parse()
 
 	args := flag.Args()
@@ -35,6 +36,9 @@ func main() {
 	opts := []yamldiff.DoOptionFunc{}
 	if *ignoreEmptyFields {
 		opts = append(opts, yamldiff.EmptyAsNull())
+	}
+	if *ignoreZeroFields {
+		opts = append(opts, yamldiff.ZeroAsNull())
 	}
 
 	fmt.Printf("--- %s\n+++ %s\n\n", file1, file2)

--- a/yamldiff/diff.go
+++ b/yamldiff/diff.go
@@ -2,6 +2,7 @@ package yamldiff
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/goccy/go-yaml"
 )
@@ -312,6 +313,8 @@ func (r *runner) handlePrimitive(rawA rawType, rawB rawType, level int) *diff {
 	case rawA == missingKey:
 		if r.option.emptyAsNull && (rawB == nil || string(strB) == "{}" || string(strB) == "[]") {
 			result.status = DiffStatusSame
+		} else if r.option.zeroAsNull && (reflect.ValueOf(rawB).IsValid() && reflect.ValueOf(rawB).IsZero()) {
+			result.status = DiffStatusSame
 		} else {
 			result.a = nil
 			result.status = DiffStatus1Missing
@@ -320,6 +323,8 @@ func (r *runner) handlePrimitive(rawA rawType, rawB rawType, level int) *diff {
 
 	case rawB == missingKey:
 		if r.option.emptyAsNull && rawA == nil {
+			result.status = DiffStatusSame
+		} else if r.option.zeroAsNull && (reflect.ValueOf(rawA).IsValid() && reflect.ValueOf(rawA).IsZero()) {
 			result.status = DiffStatusSame
 		} else {
 			result.b = nil

--- a/yamldiff/diff_test.go
+++ b/yamldiff/diff_test.go
@@ -497,6 +497,80 @@ func Test_performDiff(t *testing.T) {
 				},
 			},
 		},
+		"#30": {
+			"zero string": {
+				a: rawTypeMap{
+					yaml.MapItem{Key: "strA", Value: "foo"},
+					yaml.MapItem{Key: "strB", Value: ""},
+					yaml.MapItem{Key: "strC", Value: ""},
+				},
+				b: rawTypeMap{
+					yaml.MapItem{Key: "strA", Value: "foo"},
+					yaml.MapItem{Key: "strB", Value: ""},
+				},
+				want: &diff{
+					children: &diffChildren{
+						m: diffChildrenMap{
+							"strA": &diff{
+								status:    DiffStatusSame,
+								a:         "foo",
+								b:         "foo",
+								treeLevel: 1,
+							},
+							"strB": &diff{
+								status:    DiffStatusSame,
+								a:         "",
+								b:         "",
+								treeLevel: 1,
+							},
+							"strC": &diff{
+								status:    DiffStatus2Missing,
+								a:         "",
+								treeLevel: 1,
+							},
+						},
+					},
+					status: DiffStatusDiff,
+				},
+			},
+			"zero int": {
+				a: rawTypeMap{
+					yaml.MapItem{Key: "intA", Value: 5},
+					yaml.MapItem{Key: "intB", Value: 0},
+					yaml.MapItem{Key: "intC", Value: 0},
+				},
+				b: rawTypeMap{
+					yaml.MapItem{Key: "intA", Value: 5},
+					yaml.MapItem{Key: "intB", Value: 0},
+				},
+				want: &diff{
+					children: &diffChildren{
+						m: diffChildrenMap{
+							"intA": &diff{
+								status:    DiffStatusSame,
+								a:         5,
+								b:         5,
+								treeLevel: 1,
+							},
+							"intB": &diff{
+								status:    DiffStatusSame,
+								a:         0,
+								b:         0,
+								treeLevel: 1,
+							},
+							"intC": &diff{
+								status:    DiffStatus2Missing,
+								a:         0,
+								diffCount: 1,
+								treeLevel: 1,
+							},
+						},
+					},
+					diffCount: 1,
+					status:    DiffStatusDiff,
+				},
+			},
+		},
 	}
 	for n, tt := range tests {
 		tt := tt
@@ -603,6 +677,108 @@ func Test_performDiff_emptyAsNull(t *testing.T) {
 					// t.Parallel()
 
 					got := (&runner{option: doOptions{emptyAsNull: true}}).performDiff(tc.a, tc.b, 0)
+
+					tc.want.a = tc.a
+					tc.want.b = tc.b
+					assert.Equal(t, tc.want, got)
+				})
+			}
+		})
+	}
+}
+
+func Test_performDiff_zeroAsNull(t *testing.T) {
+	tests := map[string]map[string]struct {
+		a    rawType
+		b    rawType
+		want *diff
+	}{
+		"#30": {
+			"zero string": {
+				a: rawTypeMap{
+					yaml.MapItem{Key: "strA", Value: "foo"},
+					yaml.MapItem{Key: "strB", Value: ""},
+					yaml.MapItem{Key: "strC", Value: ""},
+				},
+				b: rawTypeMap{
+					yaml.MapItem{Key: "strA", Value: "foo"},
+					yaml.MapItem{Key: "strB", Value: ""},
+				},
+				want: &diff{
+					children: &diffChildren{
+						m: diffChildrenMap{
+							"strA": &diff{
+								status:    DiffStatusSame,
+								a:         "foo",
+								b:         "foo",
+								treeLevel: 1,
+							},
+							"strB": &diff{
+								status:    DiffStatusSame,
+								a:         "",
+								b:         "",
+								treeLevel: 1,
+							},
+							"strC": &diff{
+								status:    DiffStatusSame,
+								a:         "",
+								b:         missingKey,
+								treeLevel: 1,
+							},
+						},
+					},
+					status: DiffStatusSame,
+				},
+			},
+			"zero int": {
+				a: rawTypeMap{
+					yaml.MapItem{Key: "intA", Value: 5},
+					yaml.MapItem{Key: "intB", Value: 0},
+					yaml.MapItem{Key: "intC", Value: 0},
+				},
+				b: rawTypeMap{
+					yaml.MapItem{Key: "intA", Value: 5},
+					yaml.MapItem{Key: "intB", Value: 0},
+				},
+				want: &diff{
+					children: &diffChildren{
+						m: diffChildrenMap{
+							"intA": &diff{
+								status:    DiffStatusSame,
+								a:         5,
+								b:         5,
+								treeLevel: 1,
+							},
+							"intB": &diff{
+								status:    DiffStatusSame,
+								a:         0,
+								b:         0,
+								treeLevel: 1,
+							},
+							"intC": &diff{
+								status:    DiffStatusSame,
+								a:         0,
+								b:         missingKey,
+								treeLevel: 1,
+							},
+						},
+					},
+					status: DiffStatusSame,
+				},
+			},
+		},
+	}
+	for n, tt := range tests {
+		tt := tt
+		t.Run(n, func(t *testing.T) {
+			// t.Parallel()
+
+			for n, tc := range tt {
+				tc := tc
+				t.Run(n, func(t *testing.T) {
+					// t.Parallel()
+
+					got := (&runner{option: doOptions{zeroAsNull: true}}).performDiff(tc.a, tc.b, 0)
 
 					tc.want.a = tc.a
 					tc.want.b = tc.b

--- a/yamldiff/yaml.go
+++ b/yamldiff/yaml.go
@@ -69,6 +69,7 @@ func (y *YamlDiff) Dump() string {
 
 type doOptions struct {
 	emptyAsNull bool
+	zeroAsNull  bool
 }
 
 type DoOptionFunc func(o *doOptions)
@@ -76,6 +77,12 @@ type DoOptionFunc func(o *doOptions)
 func EmptyAsNull() DoOptionFunc {
 	return func(o *doOptions) {
 		o.emptyAsNull = true
+	}
+}
+
+func ZeroAsNull() DoOptionFunc {
+	return func(o *doOptions) {
+		o.zeroAsNull = true
 	}
 }
 

--- a/yamldiff/yaml_test.go
+++ b/yamldiff/yaml_test.go
@@ -50,6 +50,12 @@ this:
   is:
     the: same
     empty:
+---
+someStr: foo
+zeroStr: ""
+someInt: 5
+zeroInt: 0
+differs: fromA
 `
 	yamlB := `
 metadata:
@@ -95,6 +101,10 @@ baz:
 this:
   is:
     the: same
+---
+someStr: foo
+someInt: 5
+differs: fromB
 `
 
 	yamlsA, err := Load(yamlA)
@@ -119,6 +129,7 @@ this:
 
 	confirm(resultOfNoOptions(), []DoOptionFunc{})
 	confirm(resultOfWithEmpty(), []DoOptionFunc{EmptyAsNull()})
+	confirm(resultOfWithZero(), []DoOptionFunc{ZeroAsNull()})
 }
 
 func resultOfNoOptions() string {
@@ -169,6 +180,13 @@ func resultOfNoOptions() string {
     is:
       the: "same"
 -     empty:
+
+  someStr: "foo"
+- zeroStr: ""
+  someInt: 5
+- zeroInt: 0
+- differs: "fromA"
++ differs: "fromB"
 
 + bar:
 +   - "missing in a.yaml"
@@ -227,6 +245,78 @@ func resultOfWithEmpty() string {
     is:
       the: "same"
       empty:
+
+  someStr: "foo"
+- zeroStr: ""
+  someInt: 5
+- zeroInt: 0
+- differs: "fromA"
++ differs: "fromB"
+
++ bar:
++   - "missing in a.yaml"
+
++ baz:
++   - "missing in a.yaml"
+
+`
+}
+
+func resultOfWithZero() string {
+	return `
+  apiVersion: "v1"
+  kind: "Service"
+  metadata:
+    name: "my-service"
+  spec:
+    selector:
+      app: "MyApp"
+    ports:
+      -
+        protocol: "TCP"
+-       port: 80
++       port: 8080
+        targetPort: 9376
+
+  apiVersion: "apps/v1"
+  kind: "Deployment"
+  metadata:
+    name: "app-deployment"
+    labels:
+      app: "MyApp"
+  spec:
+-   replicas: 3
++   replicas: 10
+    selector:
+      matchLabels:
+        app: "MyApp"
+    template:
+      metadata:
+        labels:
+          app: "MyApp"
+      spec:
+        containers:
+          -
+            name: "app"
+-           image: "my-app:1.0.0"
++           image: "my-app:1.1.0"
+            ports:
+              -
+                containerPort: 9376
+
+- foo: "missing-in-b"
+
+  this:
+    is:
+      the: "same"
+-     empty:
+
+  someStr: "foo"
+  zeroStr: ""
+  someInt: 5
+  zeroInt: 0
+- differs: "fromA"
++ differs: "fromB"
 
 + bar:
 +   - "missing in a.yaml"


### PR DESCRIPTION
Since EmptyAsNull got introduced in v1.1 with its framework, adding this feature was quite straightforward.

The slight performance toll of using reflect should only happen when actually opting in `ZeroAsNull` and I think there will be no better way of doing it without knowing the types beforehand.

[Definition of `omitempty`](https://pkg.go.dev/encoding/json?utm_source=godoc#Marshal):

> Struct values encode as JSON objects. Each exported struct field becomes a member of the object, using the field name as the object key, unless the field is omitted for one of the reasons given below.
> 
> The encoding of each struct field can be customized by the format string stored under the "json" key in the struct field's tag. The format string gives the name of the field, possibly followed by a comma-separated list of options. The name may be empty in order to specify options without overriding the default field name.
> 
> The "omitempty" option specifies that the field should be omitted from the encoding if the field has an empty value, defined as false, 0, a nil pointer, a nil interface value, and any empty array, slice, map, or string.

[Difference of reflect.Value.IsValid and reflect.Value.IsZero to prevent confusion](https://github.com/golang/go/issues/34152#issuecomment-528976806):

> The documentation for reflect.Value.IsValid says "It returns false if v is the zero Value". Note the uppercase Value, it's referring to the reflect.Value, an abstract representation of any Go value.
> 
> The documentation for reflect.Value.IsZero says "IsZero reports whether v is the zero value for its type". Note the lowercase value, it's referring the underlying Go value that the reflect.Value is representing.

So we can safely say that `reflect.Value.IsZero` is matching exactly the case of `omitempty`, if the user decides to opt in to this behaviour using `ZeroAsNull`.

**There is strange behavior in tests!** Even though I added the yaml testcase as last document in [yamlA](https://github.com/dionysius/yaml-diff/blob/opt_zeroasnull/yamldiff/yaml_test.go#L54) and [yamlB](https://github.com/dionysius/yaml-diff/blob/opt_zeroasnull/yamldiff/yaml_test.go#L105) **all** existing results ([resultOfNoOptions](https://github.com/dionysius/yaml-diff/blob/opt_zeroasnull/yamldiff/yaml_test.go#L184), [resultOfWithEmpty](https://github.com/dionysius/yaml-diff/blob/opt_zeroasnull/yamldiff/yaml_test.go#L249) and the new [resultOfWithZero](https://github.com/dionysius/yaml-diff/blob/opt_zeroasnull/yamldiff/yaml_test.go#L314)) strangely expect the diff inbetween. You might want to look into that.

Edits to my branch are allowed if you want to extend the PR.